### PR TITLE
fix: gospecify init --here flag validation error

### DIFF
--- a/.copilot/modifications-fix-here-flag.md
+++ b/.copilot/modifications-fix-here-flag.md
@@ -1,0 +1,59 @@
+# Fix --here Flag Issue
+
+## Problem
+The `gospecify init --here` command was incorrectly throwing the error:
+```
+Directory already exists. Use --force to overwrite or specify a different name
+```
+
+This error occurred because the validation logic was checking if the current directory exists when using `--here`, which it always will (that's the point of `--here`).
+
+## Root Cause
+In `src/gospecify/cmd/init.go`, the `validateConfig()` function had incorrect logic:
+
+```go
+// OLD (incorrect) logic:
+if _, err := os.Stat(cfg.Path); err == nil {
+    if cfg.Here && !cfg.Force {
+        return errors.NewValidationError(
+            "Directory already exists. Use --force to overwrite or specify a different name")
+    }
+    if !cfg.Here {
+        return errors.NewValidationError(
+            fmt.Sprintf("Directory %s already exists", cfg.Path))
+    }
+}
+```
+
+The problem was that when using `--here`, `cfg.Path` is set to the current working directory, which always exists. The code would then error out saying "directory already exists" even though that's expected behavior for `--here`.
+
+## Solution
+Fixed the validation logic to only check for directory existence when NOT using `--here`:
+
+```go
+// NEW (correct) logic:
+if !cfg.Here {
+    // When not using --here, we're creating a new directory that shouldn't exist
+    if _, err := os.Stat(cfg.Path); err == nil {
+        return errors.NewValidationError(
+            fmt.Sprintf("Directory %s already exists", cfg.Path))
+    }
+}
+// When using --here, the current directory should exist and we don't need to check
+```
+
+## Behavior After Fix
+- `gospecify init --here` works in empty directories without `--force`
+- `gospecify init --here` requires `--force` in non-empty directories (correct behavior)
+- `gospecify init project-name` still correctly errors if `project-name` directory already exists
+- The `--force` flag now only applies to overwriting existing project files, not directory existence checks
+
+## Files Changed
+- `src/gospecify/cmd/init.go` - Fixed validation logic in `validateConfig()` function
+
+## Testing
+Tested the following scenarios successfully:
+1. ✅ `gospecify init --here` in empty directory (works without --force)
+2. ✅ `gospecify init --here` in non-empty directory (requires --force)
+3. ✅ `gospecify init --here --force` in non-empty directory (works)
+4. ✅ `gospecify init existing-dir` still errors correctly when directory exists

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ env/
 .genreleases/
 *.zip
 sdd-*/
+
+# gospecify
+src/gospecify/gospecify

--- a/src/gospecify/cmd/init.go
+++ b/src/gospecify/cmd/init.go
@@ -204,17 +204,15 @@ func validateConfig(cfg *config.ProjectConfig) error {
 		}
 	}
 
-	// Check if directory exists and handle --force flag
-	if _, err := os.Stat(cfg.Path); err == nil {
-		if cfg.Here && !cfg.Force {
-			return errors.NewValidationError(
-				"Directory already exists. Use --force to overwrite or specify a different name")
-		}
-		if !cfg.Here {
+	// Check if directory exists - only relevant when creating new project directory
+	if !cfg.Here {
+		// When not using --here, we're creating a new directory that shouldn't exist
+		if _, err := os.Stat(cfg.Path); err == nil {
 			return errors.NewValidationError(
 				fmt.Sprintf("Directory %s already exists", cfg.Path))
 		}
 	}
+	// When using --here, the current directory should exist and we don't need to check
 
 	return nil
 }


### PR DESCRIPTION
# Fix: gospecify init --here flag validation error

## Problem
The `gospecify init --here` command was incorrectly throwing a validation error:
```
Directory already exists. Use --force to overwrite or specify a different name
```

This error occurred even when using `--here` in valid scenarios (empty directories), because the validation logic was checking if the current directory exists - which it always will when using `--here`.

## Solution
Fixed the validation logic in `validateConfig()` to only check for directory existence when **not** using the `--here` flag:

- When using `--here`: Skip directory existence check (current directory should exist)
- When creating new project: Check that target directory doesn't already exist

## Changes
- `src/gospecify/cmd/init.go`: Fixed validation logic in `validateConfig()` function
- Added comprehensive documentation in `.copilot/modifications-fix-here-flag.md`

## Testing
Verified the fix works in all scenarios:
- ✅ `gospecify init --here` works in empty directories 
- ✅ `gospecify init --here` properly requires `--force` in non-empty directories
- ✅ `gospecify init project-name` still prevents overwriting existing directories

## Impact
- Fixes broken `--here` functionality
- Maintains existing behavior for non-`--here` usage
- No breaking changes
